### PR TITLE
improve: Background logging concurrency safety

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
+          version: v2.9.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: v1.26.2
+          version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: wooak
 
 before:


### PR DESCRIPTION
## 📋 Description

This PR refactors the lifecycle management of `AuditLogger`’s background worker:

* Introduces **`startOnce`** and **`stopOnce`** to replace manual `started` flag handling.
* Ensures `StartBackgroundLogging()` is only executed once.
* Ensures `StopBackgroundLogging()` is idempotent and only shuts down once.

## 🔗 Related Issues

close #18 

## 🧪 Type of Change

- [x] ♻️ Code refactoring
- [x] 🎃 Hacktoberfest contribution

## 🧪 Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

### Test Results

## 📸 Screenshots (if applicable)

## 📋 Checklist

<!-- Mark completed items with an "x" -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

### Documentation
- [ ] I have updated the README.md if necessary
- [ ] I have updated the CONTRIBUTING.md if necessary
- [x] I have added/updated code comments where necessary
- [ ] I have updated any relevant documentation

### Hacktoberfest (if applicable)
- [x] This is a meaningful contribution that adds value to the project
- [x] I have followed the project's contribution guidelines
- [x] I have read and agree to the Code of Conduct
- [x] This contribution is not spam or low-quality

## 🚀 Deployment Notes

<!-- Any special deployment considerations -->

## 📝 Additional Notes

<!-- Any additional information that reviewers should know -->

---

**By submitting this pull request, I confirm that:**

- [x] I have read and agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and followed the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My contribution is original work and I have the right to submit it
- [x] I understand that my contribution may be modified or rejected at the maintainer's discretion
